### PR TITLE
Add simple BFS-based monster pathfinding

### DIFF
--- a/src/js/entities/monsters/Monster.js
+++ b/src/js/entities/monsters/Monster.js
@@ -1,10 +1,11 @@
 // src/js/entities/monsters/Monster.js
 import * as PIXI from 'pixi.js';
 import { MONSTER_CONFIG } from '../../config/GameConfig.js';
-import { 
-    velocityToDirectionString, 
-    directionStringToAngleRadians 
+import {
+    velocityToDirectionString,
+    directionStringToAngleRadians
 } from '../../utils/DirectionUtils.js';
+import { bfsPath } from '../../utils/Pathfinding.js';
 
 export class Monster {
     constructor(options) {
@@ -28,6 +29,8 @@ export class Monster {
         this.previousState = 'idle'; // Used for state transitions
         this.target = null;
         this.attackCooldown = 0;
+        this.path = [];
+        this.pathCooldown = 0;
         
         // Animation state
         this.currentAnimation = null;
@@ -261,7 +264,7 @@ export class Monster {
         }
         
         // AI state machine
-        this.updateAI(deltaTime, player);
+        this.updateAI(deltaTime, player, world);
         
         // Apply movement
         this.position.x += this.velocity.x;
@@ -274,7 +277,7 @@ export class Monster {
         this.updateAnimation();
     }
     
-    updateAI(deltaTime, player) {
+    updateAI(deltaTime, player, world) {
         // Check if we need to acquire a target
         if (!this.target) {
             const dx = player.position.x - this.position.x;
@@ -305,34 +308,64 @@ export class Monster {
             const dx = this.target.position.x - this.position.x;
             const dy = this.target.position.y - this.position.y;
             const distToTarget = Math.sqrt(dx * dx + dy * dy);
-            
+
             // Update facing toward target
             this.updateFacingToTarget();
-            
-            if (distToTarget > this.attackRange) {
-                // Move towards target
-                const moveSpeed = this.moveSpeed / distToTarget;
-                this.velocity.x = dx * moveSpeed;
-                this.velocity.y = dy * moveSpeed;
-                
-                // Only change to walking if we're currently idle
-                if (this.state === 'idle') {
-                    this.changeState('walking');
+
+            // Recalculate path periodically
+            if (this.pathCooldown > 0) {
+                this.pathCooldown -= deltaTime;
+            }
+
+            if (this.path.length === 0 || this.pathCooldown <= 0) {
+                const newPath = bfsPath(world, this.position, this.target.position);
+                if (newPath) {
+                    this.path = newPath;
+                } else {
+                    this.path = [];
                 }
-            } else {
-                // In attack range, stop and attack
-                this.velocity.x = 0;
-                this.velocity.y = 0;
-                
-                // Attack if cooldown is ready and not already attacking
-                if (this.attackCooldown <= 0 && this.state !== 'attacking') {
-                    this.startAttack();
+                this.pathCooldown = 1; // recalc every second
+            }
+
+            let movedViaPath = false;
+            if (this.path.length > 0) {
+                const next = this.path[0];
+                const pdx = next.x - this.position.x;
+                const pdy = next.y - this.position.y;
+                const dist = Math.sqrt(pdx * pdx + pdy * pdy);
+                if (dist < this.moveSpeed) {
+                    this.path.shift();
+                }
+                if (dist > 0) {
+                    const moveSpeed = this.moveSpeed / dist;
+                    this.velocity.x = pdx * moveSpeed;
+                    this.velocity.y = pdy * moveSpeed;
+                    movedViaPath = true;
                 }
             }
-            
-            // Lose target if they get too far away
+
+            if (!movedViaPath) {
+                if (distToTarget > this.attackRange) {
+                    const moveSpeed = this.moveSpeed / distToTarget;
+                    this.velocity.x = dx * moveSpeed;
+                    this.velocity.y = dy * moveSpeed;
+
+                    if (this.state === 'idle') {
+                        this.changeState('walking');
+                    }
+                } else {
+                    this.velocity.x = 0;
+                    this.velocity.y = 0;
+
+                    if (this.attackCooldown <= 0 && this.state !== 'attacking') {
+                        this.startAttack();
+                    }
+                }
+            }
+
             if (distToTarget > this.aggroRange * 1.5) {
                 this.target = null;
+                this.path = [];
                 this.velocity.x = 0;
                 this.velocity.y = 0;
                 this.changeState('idle');

--- a/src/js/utils/Pathfinding.js
+++ b/src/js/utils/Pathfinding.js
@@ -1,0 +1,40 @@
+export function bfsPath(world, start, goal, maxSteps = 500) {
+  const startTile = {
+    x: Math.floor(start.x / world.tileSize),
+    y: Math.floor(start.y / world.tileSize)
+  };
+  const goalTile = {
+    x: Math.floor(goal.x / world.tileSize),
+    y: Math.floor(goal.y / world.tileSize)
+  };
+  const queue = [];
+  const visited = new Set();
+  const key = (x,y) => `${x},${y}`;
+  queue.push({x:startTile.x, y:startTile.y, path: []});
+  visited.add(key(startTile.x, startTile.y));
+  const dirs = [
+    {dx:1,dy:0}, {dx:-1,dy:0}, {dx:0,dy:1}, {dx:0,dy:-1}
+  ];
+  while (queue.length > 0) {
+    const node = queue.shift();
+    if (node.x === goalTile.x && node.y === goalTile.y) {
+      return node.path;
+    }
+    for (const dir of dirs) {
+      const nx = node.x + dir.dx;
+      const ny = node.y + dir.dy;
+      if (nx < 0 || ny < 0 || nx >= world.width || ny >= world.height) continue;
+      if (!world.tiles[ny][nx].isWalkable()) continue;
+      const k = key(nx, ny);
+      if (visited.has(k)) continue;
+      visited.add(k);
+      const newPath = node.path.concat({
+        x: nx * world.tileSize + world.tileSize / 2,
+        y: ny * world.tileSize + world.tileSize / 2
+      });
+      queue.push({x: nx, y: ny, path: newPath});
+      if (visited.size > maxSteps) return null;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add lightweight BFS pathfinding utility
- use BFS in monster AI to follow a path around impassable tiles like water
- update monster update logic to pass world

## Testing
- `npm test` *(fails: Error: no test specified)*