### PR TITLE
Add persistent XP and level-up effect

### DIFF
--- a/src/js/config/GameConfig.js
+++ b/src/js/config/GameConfig.js
@@ -5,6 +5,7 @@ export const MONSTER_CONFIG = {
   stats: {
     ogre: {
       hitPoints: 4, moveSpeed: 2, attackRange: 90, collisionRadius: 35, aggroRange: 800,
+      xp: 20,
       animations: { // Animation properties
         walk: { speed: 0.3 }, idle: { speed: 0.2 }, attack1: { speed: 0.25, hitFrame: 9 },
         take_damage: { speed: 0.7 }, die: { speed: 0.2 }
@@ -12,6 +13,7 @@ export const MONSTER_CONFIG = {
     },
     skeleton: {
       hitPoints: 2, moveSpeed: 2.5, attackRange: 70, collisionRadius: 15, aggroRange: 1200,
+      xp: 5,
       animations: { // Animation properties
         walk: { speed: 0.4 }, idle: { speed: 0.2 }, attack1: { speed: 0.3, hitFrame: 8 },
         take_damage: { speed: 0.7 }, die: { speed: 0.5 }
@@ -19,6 +21,7 @@ export const MONSTER_CONFIG = {
     },
     elemental: {
       hitPoints: 3, moveSpeed: 2, attackRange: 100, collisionRadius: 15, aggroRange: 800,
+      xp: 10,
       animations: { // Animation properties
         walk: { speed: 0.4 }, idle: { speed: 0.2 }, attack1: { speed: 0.3, hitFrame: 8 },
         take_damage: { speed: 0.7 }, die: { speed: 0.2 }
@@ -26,6 +29,7 @@ export const MONSTER_CONFIG = {
     },
     ghoul: {
       hitPoints: 2, moveSpeed: 3.5, attackRange: 70, collisionRadius: 10, aggroRange: 3000,
+      xp: 15,
       animations: { // Animation properties
         walk: { speed: 0.45 }, idle: { speed: 0.25 }, attack1: { speed: 0.4, hitFrame: 7 },
         take_damage: { speed: 0.7 }, die: { speed: 0.25 }
@@ -158,6 +162,12 @@ export const PLAYER_CONFIG = {
   damage: {
     stunDuration: 0.25, // Stun duration in seconds when taking damage
     flashDuration: 0.1  // Duration of red tint flash when damaged
+  },
+
+  // Leveling configuration
+  levels: {
+    maxLevel: 10,
+    xpGrowth: 20 // XP required to level up = current level * xpGrowth
   },
   
   attacks: {

--- a/src/js/core/Game.js
+++ b/src/js/core/Game.js
@@ -9,6 +9,7 @@ import { MonsterSystem }  from '../systems/MonsterSystem.js';
 import { SpriteManager }  from '../systems/animation/SpriteManager.js';
 import { TilesetManager } from '../systems/tiles/TilesetManager.js';
 import { HealthUI } from '../ui/HealthUI.js';
+import { StatsUI } from '../ui/StatsUI.js';
 import { ClassSelectUI } from '../ui/ClassSelectUI.js'; // Import the new UI
 
 // 1) turn off antialias & force pixel‐perfect
@@ -36,6 +37,7 @@ export class Game {
     this.worldContainer  = new PIXI.Container();
     this.entityContainer = new PIXI.Container();
     this.uiContainer = new PIXI.Container();
+    this.uiContainer.sortableChildren = true;
     this.app.stage.addChild(this.worldContainer);
     this.app.stage.addChild(this.entityContainer);
     this.app.stage.addChild(this.uiContainer);
@@ -107,9 +109,11 @@ export class Game {
     });
     this.entityContainer.addChild(this.entities.player.sprite);
 
-    // Add health UI
+    // Add health and stats UI
     this.healthUI = new HealthUI(this.entities.player);
+    this.statsUI = new StatsUI(this.entities.player);
     this.uiContainer.addChild(this.healthUI.container);
+    this.uiContainer.addChild(this.statsUI.container);
 
     this.systems.monsters = new MonsterSystem(this.systems.world);
 
@@ -143,6 +147,7 @@ export class Game {
     this.systems.combat.update(deltaTimeSeconds);
     this.updateCamera(); // Depends on player's final position after physics
     this.healthUI.update();
+    if (this.statsUI) this.statsUI.update();
   }
 
   updateCamera() {

--- a/src/js/entities/monsters/Monster.js
+++ b/src/js/entities/monsters/Monster.js
@@ -205,7 +205,7 @@ export class Monster {
         }
     }
     
-    takeDamage(amount) {
+    takeDamage(amount, attacker = null) {
         // Don't process damage if already dead
         if (!this.alive) return;
         
@@ -213,7 +213,7 @@ export class Monster {
         
         // Check for death
         if (this.hitPoints <= 0) {
-            this.die();
+            this.die(attacker);
             return;
         }
         
@@ -227,11 +227,14 @@ export class Monster {
         this.velocity = { x: 0, y: 0 }; // Stop movement
     }
     
-    die() {
+    die(attacker = null) {
         if (!this.alive) return;
         
         console.log(`Monster ${this.type} has been defeated!`);
         this.alive = false;
+        if (attacker && attacker.stats && attacker.stats.recordKill) {
+            attacker.stats.recordKill(this.type);
+        }
         this.changeState('dying');
         this.velocity = { x: 0, y: 0 };
         

--- a/src/js/systems/CombatSystem.js
+++ b/src/js/systems/CombatSystem.js
@@ -143,7 +143,7 @@ export class CombatSystem {
         for (const monster of monsters) {
             if (!monster.alive) continue;
             if (projectile.checkCollision(monster)) {
-                monster.takeDamage(projectile.damage);
+                monster.takeDamage(projectile.damage, projectile.owner);
                 projectile.deactivate();
                 break;
             }
@@ -507,7 +507,7 @@ _executeProjectileAttack(entity, attackConfig, attackType) {
     for (const monster of monsters) {
       if (!monster.alive) continue;
       if (hitbox.testHit(monster, monster.collisionRadius || 0)) {
-        monster.takeDamage(damage);
+        monster.takeDamage(damage, entity);
       }
     }
   }

--- a/src/js/ui/StatsUI.js
+++ b/src/js/ui/StatsUI.js
@@ -1,0 +1,32 @@
+import * as PIXI from 'pixi.js';
+
+export class StatsUI {
+    constructor(player) {
+        this.player = player;
+        this.container = new PIXI.Container();
+        this.container.position.set(20, 60); // below health UI
+        this.container.zIndex = 100;
+
+        this.killText = new PIXI.Text('', { fontFamily: 'Arial', fontSize: 16, fill: 0xffffff });
+        this.xpText = new PIXI.Text('', { fontFamily: 'Arial', fontSize: 16, fill: 0xffffff });
+        this.xpToNextText = new PIXI.Text('', { fontFamily: 'Arial', fontSize: 16, fill: 0xffffff });
+        this.levelText = new PIXI.Text('', { fontFamily: 'Arial', fontSize: 16, fill: 0xffffff });
+
+        this.xpText.position.set(0, 20);
+        this.xpToNextText.position.set(0, 40);
+        this.levelText.position.set(0, 60);
+
+        this.container.addChild(this.killText, this.xpText, this.xpToNextText, this.levelText);
+        this.update();
+    }
+
+    update() {
+        this.killText.text = `Kills: ${this.player.killCount}`;
+        this.xpText.text = `XP: ${Math.floor(this.player.experience)}`;
+        if (this.player.stats && this.player.stats.getXpUntilNextLevel) {
+            const remaining = Math.ceil(this.player.stats.getXpUntilNextLevel());
+            this.xpToNextText.text = `XP to Next: ${remaining}`;
+        }
+        this.levelText.text = `Level: ${this.player.level}`;
+    }
+}


### PR DESCRIPTION
## Summary
- keep total experience when leveling
- show XP required for next level in Stats UI
- highlight player sprite with a golden tint on level up
- enable z-index sorting on the UI container

## Testing
- `npm test` *(fails: Error: no test specified)*