### PR TITLE
Add initial multiplayer networking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "hardmode",
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "vite src"
+    "dev": "vite src",
+    "server": "node src/server/server.js"
   },
   "keywords": [],
   "author": "",

--- a/src/js/core/Game.js
+++ b/src/js/core/Game.js
@@ -11,6 +11,7 @@ import { TilesetManager } from '../systems/tiles/TilesetManager.js';
 import { HealthUI } from '../ui/HealthUI.js';
 import { StatsUI } from '../ui/StatsUI.js';
 import { ClassSelectUI } from '../ui/ClassSelectUI.js'; // Import the new UI
+import { NetworkClient } from '../network/NetworkClient.js';
 
 // Toggle display of extra stat information in the Stats UI
 const SHOW_DEBUG_STATS = true;
@@ -56,6 +57,8 @@ export class Game {
     };
 
     this.entities = { player: null };
+    this.otherPlayers = {};
+    this.network = null;
     window.game = this;
 
     this.tilesets = new TilesetManager();
@@ -112,6 +115,13 @@ export class Game {
     });
     this.entityContainer.addChild(this.entities.player.sprite);
 
+    // Initialize networking
+    this.network = new NetworkClient();
+    this.network.join(selectedClass);
+    this.network.on('playerJoined', (d) => this.handlePlayerJoined(d));
+    this.network.on('playerLeft', (id) => this.handlePlayerLeft(id));
+    this.network.on('worldState', (s) => this.handleWorldState(s));
+
     // Add health and stats UI
     this.healthUI = new HealthUI(this.entities.player);
     this.statsUI = new StatsUI(this.entities.player, { showDebug: SHOW_DEBUG_STATS });
@@ -151,6 +161,14 @@ export class Game {
     this.updateCamera(); // Depends on player's final position after physics
     this.healthUI.update();
     if (this.statsUI) this.statsUI.update();
+
+    if (this.network) {
+      this.network.sendState({
+        x: this.entities.player.position.x,
+        y: this.entities.player.position.y,
+        facing: this.entities.player.facing
+      });
+    }
   }
 
   updateCamera() {
@@ -166,5 +184,52 @@ export class Game {
       Math.floor(this.app.screen.width / 2 - this.camera.x),
       Math.floor(this.app.screen.height / 2 - this.camera.y)
     );
+  }
+
+  handlePlayerJoined(data) {
+    if (data.id === this.network.socket.id) return;
+    if (this.otherPlayers[data.id]) return;
+    const p = new Player({
+      x: data.x,
+      y: data.y,
+      class: data.class,
+      combatSystem: this.systems.combat,
+      spriteManager: this.systems.sprites
+    });
+    this.entityContainer.addChild(p.sprite);
+    this.otherPlayers[data.id] = p;
+  }
+
+  handlePlayerLeft(id) {
+    const p = this.otherPlayers[id];
+    if (p) {
+      this.entityContainer.removeChild(p.sprite);
+      delete this.otherPlayers[id];
+    }
+  }
+
+  handleWorldState(state) {
+    for (const id in state) {
+      if (id === this.network.socket.id) continue;
+      const info = state[id];
+      let p = this.otherPlayers[id];
+      if (!p) {
+        p = new Player({
+          x: info.x,
+          y: info.y,
+          class: info.class,
+          combatSystem: this.systems.combat,
+          spriteManager: this.systems.sprites
+        });
+        this.entityContainer.addChild(p.sprite);
+        this.otherPlayers[id] = p;
+      } else {
+        p.position.x = info.x;
+        p.position.y = info.y;
+        p.facing = info.facing;
+        p.sprite.position.set(info.x, info.y);
+        p.animation.update();
+      }
+    }
   }
 }

--- a/src/js/network/NetworkClient.js
+++ b/src/js/network/NetworkClient.js
@@ -1,0 +1,33 @@
+import { io } from 'socket.io/client-dist/socket.io.esm.min.js';
+
+export class NetworkClient {
+    constructor() {
+        this.socket = io('ws://localhost:3000');
+        this.handlers = {};
+        this.socket.on('connect', () => console.log('Connected:', this.socket.id));
+        this.socket.on('playerJoined', data => this.emit('playerJoined', data));
+        this.socket.on('playerLeft', id => this.emit('playerLeft', id));
+        this.socket.on('worldState', state => this.emit('worldState', state));
+    }
+
+    join(characterClass) {
+        this.socket.emit('join', { class: characterClass });
+    }
+
+    sendState(state) {
+        this.socket.emit('state', state);
+    }
+
+    on(event, fn) {
+        if (!this.handlers[event]) {
+            this.handlers[event] = [];
+        }
+        this.handlers[event].push(fn);
+    }
+
+    emit(event, data) {
+        if (this.handlers[event]) {
+            this.handlers[event].forEach(fn => fn(data));
+        }
+    }
+}

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,0 +1,49 @@
+import express from 'express';
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+
+const app = express();
+const httpServer = createServer(app);
+const io = new Server(httpServer, {
+    cors: { origin: '*' }
+});
+
+const players = {};
+
+io.on('connection', socket => {
+    console.log('Client connected', socket.id);
+
+    socket.on('join', data => {
+        players[socket.id] = {
+            id: socket.id,
+            x: 0,
+            y: 0,
+            facing: 'down',
+            class: data?.class || 'bladedancer'
+        };
+        io.emit('playerJoined', players[socket.id]);
+    });
+
+    socket.on('state', state => {
+        if (players[socket.id]) {
+            players[socket.id].x = state.x;
+            players[socket.id].y = state.y;
+            players[socket.id].facing = state.facing;
+        }
+    });
+
+    socket.on('disconnect', () => {
+        console.log('Client disconnected', socket.id);
+        delete players[socket.id];
+        io.emit('playerLeft', socket.id);
+    });
+});
+
+setInterval(() => {
+    io.emit('worldState', players);
+}, 100);
+
+const PORT = process.env.PORT || 3000;
+httpServer.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- configure Node to use ES modules and add a server script
- implement a basic Socket.io game server
- add a simple Socket.io client wrapper
- wire networking into the game to sync player state

## Testing
- `npm test` *(fails: Error: no test specified)*