### PR TITLE
Enable deterministic world sharing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "hardmode",
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "vite src"
+    "dev": "vite src",
+    "server": "node src/server/server.js"
   },
   "keywords": [],
   "author": "",
@@ -14,7 +16,9 @@
     "express": "^5.1.0",
     "pixi.js": "^7.4.3",
     "simplex-noise": "^4.0.3",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "socket.io-client": "^4.8.1",
+    "seedrandom": "^3.0.5"
   },
   "devDependencies": {
     "vite": "^6.3.2"

--- a/src/js/entities/Player.js
+++ b/src/js/entities/Player.js
@@ -175,7 +175,9 @@ class AnimationComponent extends Component {
             
             // Get appropriate animation based on state
             const animationName = this.owner.spriteManager.getAnimationForMovement(
-                this.owner.facing, this.owner.movementDirection
+                this.owner.facing,
+                this.owner.movementDirection,
+                this.owner.characterClass
             );
             
             if (animationName && (facingChanged || this.owner.currentAnimation !== animationName)) {
@@ -196,7 +198,11 @@ class AnimationComponent extends Component {
         }
         
         // Create idle animation for current facing direction
-        const animationName = this.owner.spriteManager.getAnimationForMovement(this.owner.facing, null);
+        const animationName = this.owner.spriteManager.getAnimationForMovement(
+            this.owner.facing,
+            null,
+            this.owner.characterClass
+        );
         this.owner.currentAnimation = animationName;
         
         this.owner.animatedSprite = this.owner.spriteManager.createAnimatedSprite(animationName);
@@ -332,7 +338,11 @@ class AnimationComponent extends Component {
         }
         
         // Regular attack animation handling
-        const attackAnimName = this.owner.spriteManager.getAttackAnimation(this.owner.facing, attackType);
+        const attackAnimName = this.owner.spriteManager.getAttackAnimation(
+            this.owner.facing,
+            attackType,
+            this.owner.characterClass
+        );
         this.owner.currentAnimation = attackAnimName;
         
         // Remove old sprite and create new attack animation

--- a/src/js/network/NetworkClient.js
+++ b/src/js/network/NetworkClient.js
@@ -1,0 +1,34 @@
+import { io } from 'socket.io-client';
+
+export class NetworkClient {
+    constructor() {
+        this.socket = io('ws://localhost:3000');
+        this.handlers = {};
+        this.socket.on('connect', () => console.log('Connected:', this.socket.id));
+        this.socket.on('playerJoined', data => this.emit('playerJoined', data));
+        this.socket.on('playerLeft', id => this.emit('playerLeft', id));
+        this.socket.on('worldState', state => this.emit('worldState', state));
+        this.socket.on('worldInit', data => this.emit('worldInit', data));
+    }
+
+    join(characterClass) {
+        this.socket.emit('join', { class: characterClass });
+    }
+
+    sendState(state) {
+        this.socket.emit('state', state);
+    }
+
+    on(event, fn) {
+        if (!this.handlers[event]) {
+            this.handlers[event] = [];
+        }
+        this.handlers[event].push(fn);
+    }
+
+    emit(event, data) {
+        if (this.handlers[event]) {
+            this.handlers[event].forEach(fn => fn(data));
+        }
+    }
+}

--- a/src/js/systems/animation/SpriteManager.js
+++ b/src/js/systems/animation/SpriteManager.js
@@ -356,14 +356,14 @@ export class SpriteManager {
 }
 
 // Update getAnimationForMovement to handle different character classes
-getAnimationForMovement(facingDirection, movementDirection) {
-    // Get current character class from the entity this animation is for
+getAnimationForMovement(facingDirection, movementDirection, characterClass) {
+    // Determine character class for this animation
     const playerEntity = window.game?.entities?.player;
-    const characterClass = playerEntity?.characterClass || 'bladedancer'; // Default to bladedancer if no player
+    const effectiveClass = characterClass || playerEntity?.characterClass || 'bladedancer';
     
     // Fetch spritePrefix from PLAYER_CONFIG
-    const classConfig = PLAYER_CONFIG.classes[characterClass];
-    const classPrefix = classConfig?.spritePrefix || 'knight'; // Default to 'knight' if not found
+    const classConfig = PLAYER_CONFIG.classes[effectiveClass];
+    const classPrefix = classConfig?.spritePrefix || 'knight';
 
     // Convert 8-way direction to the animation suffix (e, se, s, etc.)
     const facingSuffix = directionStringToAnimationSuffix(facingDirection);
@@ -426,14 +426,14 @@ getAnimationForMovement(facingDirection, movementDirection) {
     }
 }
     
-getAttackAnimation(facingDirection, attackType) {
-    // Get current character class
+getAttackAnimation(facingDirection, attackType, characterClass) {
+    // Determine character class for this animation
     const playerEntity = window.game?.entities?.player;
-    const characterClass = playerEntity?.characterClass || 'bladedancer'; // Default to bladedancer
+    const effectiveClass = characterClass || playerEntity?.characterClass || 'bladedancer';
     
     // Fetch spritePrefix from PLAYER_CONFIG
-    const classConfig = PLAYER_CONFIG.classes[characterClass];
-    const classPrefix = classConfig?.spritePrefix || 'knight'; // Default to 'knight'
+    const classConfig = PLAYER_CONFIG.classes[effectiveClass];
+    const classPrefix = classConfig?.spritePrefix || 'knight';
 
     // Convert 8-way direction string to animation suffix
     const facingSuffix = directionStringToAnimationSuffix(facingDirection);

--- a/src/js/systems/world/WorldGenerator.js
+++ b/src/js/systems/world/WorldGenerator.js
@@ -2,6 +2,7 @@
 import * as PIXI from 'pixi.js';
 import { Tile } from './Tile.js';
 import { createNoise2D } from 'simplex-noise';
+import seedrandom from 'seedrandom';
 import { DecorationManager } from '../tiles/DecorationManager.js';
 
 export class WorldGenerator {
@@ -10,8 +11,10 @@ export class WorldGenerator {
     this.height = options.height || 100;
     this.tileSize = options.tileSize || 32;
     this.tilesets = options.tilesets;
-    this.noise2D = createNoise2D();
-    this.waterNoise2D = createNoise2D(Math.random);
+    this.seed = options.seed || Math.floor(Math.random() * 1e8).toString();
+    const rng = seedrandom(this.seed);
+    this.noise2D = createNoise2D(rng);
+    this.waterNoise2D = createNoise2D(seedrandom(this.seed + '_water'));
     this.decorations = null;
     this.container = new PIXI.Container();
     this.tiles = [];

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,0 +1,56 @@
+import express from 'express';
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import seedrandom from 'seedrandom';
+
+const app = express();
+const httpServer = createServer(app);
+const io = new Server(httpServer, {
+    cors: { origin: '*' }
+});
+
+// Use a deterministic seed for the world so all clients share the same layout
+const worldSeed = Math.floor(seedrandom()() * 1e8).toString();
+
+const players = {};
+
+io.on('connection', socket => {
+    console.log('Client connected', socket.id);
+
+    // Send world seed and existing players to the newly connected client
+    socket.emit('worldInit', { seed: worldSeed, players });
+
+    socket.on('join', data => {
+        players[socket.id] = {
+            id: socket.id,
+            x: 0,
+            y: 0,
+            facing: 'down',
+            class: data?.class || 'bladedancer'
+        };
+        io.emit('playerJoined', players[socket.id]);
+    });
+
+    socket.on('state', state => {
+        if (players[socket.id]) {
+            players[socket.id].x = state.x;
+            players[socket.id].y = state.y;
+            players[socket.id].facing = state.facing;
+        }
+    });
+
+    socket.on('disconnect', () => {
+        console.log('Client disconnected', socket.id);
+        delete players[socket.id];
+        io.emit('playerLeft', socket.id);
+    });
+});
+
+setInterval(() => {
+    io.emit('worldState', players);
+}, 100);
+
+const PORT = process.env.PORT || 3000;
+httpServer.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add `socket.io-client` and `seedrandom` dependencies
- fix network import to use `socket.io-client`
- seed world generation so all clients share the same map
- send world seed from the server on connection
- wait for `worldInit` before creating the world on the client
- use each player's class when selecting animations

## Testing
- `npm test` *(fails: Error: no test specified)*