### PR TITLE
Add server-side combat logic

### DIFF
--- a/src/js/entities/Player.js
+++ b/src/js/entities/Player.js
@@ -496,7 +496,7 @@ class CombatComponent extends Component {
         }
       }
     
-    performPrimaryAttack() {
+    performPrimaryAttack(skipNetwork = false) {
       console.log(`Primary attack (${this.owner.characterClass === 'guardian' ? 'sweeping axe' : 'forehand slash'}) started`);
       this.owner.isAttacking = true;
       this.owner.attackHitFrameReached = false;
@@ -505,14 +505,16 @@ class CombatComponent extends Component {
       // Play attack animation
       this.owner.animation.playAttackAnimation('primary');
       
-      // Execute attack using combat system
+      if (!skipNetwork && window.game && window.game.network) {
+        window.game.network.sendAction({ type: 'attack' });
+      }
       if (this.owner.combatSystem) {
         const cooldown = this.owner.combatSystem.executeAttack(this.owner, 'primary');
-        this.owner.primaryAttackCooldown = cooldown / 1000; // Store in the correct variable
+        this.owner.primaryAttackCooldown = cooldown / 1000;
       }
     }
     
-    performSecondaryAttack() {
+    performSecondaryAttack(skipNetwork = false) {
       console.log(`Secondary attack (${this.owner.characterClass === 'guardian' ? 'jump attack' : 'overhead smash'}) started`);
       this.owner.isAttacking = true;
       this.owner.attackHitFrameReached = false;
@@ -521,14 +523,16 @@ class CombatComponent extends Component {
       // Play attack animation
       this.owner.animation.playAttackAnimation('secondary');
       
-      // Execute attack using combat system
+      if (!skipNetwork && window.game && window.game.network) {
+        window.game.network.sendAction({ type: 'secondary' });
+      }
       if (this.owner.combatSystem) {
         const cooldown = this.owner.combatSystem.executeAttack(this.owner, 'secondary');
-        this.owner.secondaryAttackCooldown = cooldown / 1000; // Store in the correct variable
+        this.owner.secondaryAttackCooldown = cooldown / 1000;
       }
     }
 
-    performRoll() {
+    performRoll(skipNetwork = false) {
       console.log('Roll started');
       this.owner.isAttacking = true;
       this.owner.attackHitFrameReached = false;
@@ -536,6 +540,9 @@ class CombatComponent extends Component {
 
       this.owner.animation.playAttackAnimation('roll');
 
+      if (!skipNetwork && window.game && window.game.network) {
+        window.game.network.sendAction({ type: 'roll' });
+      }
       if (this.owner.combatSystem) {
         const cooldown = this.owner.combatSystem.executeAttack(this.owner, 'roll');
         this.owner.rollCooldown = cooldown / 1000;

--- a/src/js/network/NetworkClient.js
+++ b/src/js/network/NetworkClient.js
@@ -9,6 +9,8 @@ export class NetworkClient {
         this.socket.on('playerLeft', id => this.emit('playerLeft', id));
         this.socket.on('worldState', state => this.emit('worldState', state));
         this.socket.on('worldInit', data => this.emit('worldInit', data));
+        this.socket.on('playerAction', data => this.emit('playerAction', data));
+        this.socket.on('spawnProjectile', d => this.emit('spawnProjectile', d));
     }
 
     join(characterClass) {
@@ -17,6 +19,14 @@ export class NetworkClient {
 
     sendState(state) {
         this.socket.emit('state', state);
+    }
+
+    sendAction(action) {
+        this.socket.emit('playerAction', action);
+    }
+
+    sendProjectile(data) {
+        this.socket.emit('spawnProjectile', data);
     }
 
     on(event, fn) {

--- a/src/js/systems/CombatSystem.js
+++ b/src/js/systems/CombatSystem.js
@@ -167,6 +167,15 @@ export class CombatSystem {
       projectile.attachVisualEffect(effectSprite);
     }
     this.projectiles.push(projectile);
+    if (window.game && window.game.network) {
+      window.game.network.sendProjectile({
+        x, y, angle,
+        damage: options.damage || 1,
+        speed: options.speed || 600,
+        range: options.range || 400,
+        effectType: options.effectType || 'bow_shot_effect'
+      });
+    }
     return projectile;
   }
 

--- a/src/server/game/Monster.js
+++ b/src/server/game/Monster.js
@@ -1,0 +1,87 @@
+import { MONSTER_CONFIG } from '../../js/config/GameConfig.js';
+
+export class Monster {
+    constructor(options) {
+        this.id = options.id;
+        this.type = options.type || 'skeleton';
+        this.x = options.x;
+        this.y = options.y;
+
+        const stats = MONSTER_CONFIG.stats[this.type] || {};
+        this.moveSpeed = stats.moveSpeed || options.moveSpeed || 2;
+        this.attackRange = stats.attackRange || options.attackRange || 60;
+        this.aggroRange = stats.aggroRange || options.aggroRange || 200;
+        this.maxHp = stats.hitPoints || 1;
+        this.hp = this.maxHp;
+
+        this.state = 'idle';
+        this.attackCooldown = 0;
+        this.facing = 'down';
+        this.alive = true;
+    }
+
+    takeDamage(amount) {
+        this.hp -= amount;
+        if (this.hp <= 0) {
+            this.alive = false;
+            this.state = 'dead';
+        }
+    }
+
+    update(delta, players) {
+        if (!this.alive) return;
+
+        if (this.attackCooldown > 0) {
+            this.attackCooldown -= delta;
+        }
+
+        // Find nearest player
+        let closest = null;
+        let closestDist = Infinity;
+        for (const id in players) {
+            const p = players[id];
+            if (p.hp <= 0) continue;
+            const dx = p.x - this.x;
+            const dy = p.y - this.y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            if (dist < closestDist) {
+                closest = p;
+                closestDist = dist;
+            }
+        }
+
+        if (closest) {
+            const dx = closest.x - this.x;
+            const dy = closest.y - this.y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+
+            if (dist > this.attackRange) {
+                // Move toward player
+                const speed = this.moveSpeed * delta;
+                if (dist > 0) {
+                    this.x += (dx / dist) * speed;
+                    this.y += (dy / dist) * speed;
+                }
+                this.state = 'walking';
+            } else {
+                if (this.attackCooldown <= 0) {
+                    const attackCfg = MONSTER_CONFIG.attacks[this.type] || {};
+                    const dmg = attackCfg.damage || 1;
+                    const cd = attackCfg.cooldown || 1.0;
+                    closest.hp = Math.max(0, (closest.hp || 0) - dmg);
+                    this.attackCooldown = cd;
+                    this.state = 'attacking';
+                } else {
+                    this.state = 'idle';
+                }
+            }
+
+            // Update facing
+            if (Math.abs(dx) > Math.abs(dy)) {
+                this.facing = dx > 0 ? 'right' : 'left';
+            } else {
+                this.facing = dy > 0 ? 'down' : 'up';
+            }
+        }
+    }
+}

--- a/src/server/game/MonsterSystem.js
+++ b/src/server/game/MonsterSystem.js
@@ -1,0 +1,74 @@
+import seedrandom from 'seedrandom';
+import { MONSTER_CONFIG } from '../../js/config/GameConfig.js';
+import { directionStringToAngleRadians } from '../../js/utils/DirectionUtils.js';
+import { Monster } from './Monster.js';
+
+export class MonsterSystem {
+    constructor(seed) {
+        this.rng = seedrandom(seed);
+        this.monsters = {};
+        this.nextId = 1;
+        this.spawnInitial();
+    }
+
+    spawnInitial() {
+        for (const spawn of MONSTER_CONFIG.testSpawns) {
+            for (let i = 0; i < spawn.count; i++) {
+                const id = this.nextId++;
+                const x = spawn.offsetX + (this.rng() - 0.5) * 200;
+                const y = spawn.offsetY + (this.rng() - 0.5) * 200;
+                this.monsters[id] = new Monster({ id, type: spawn.type, x, y });
+            }
+        }
+    }
+
+    update(delta, players) {
+        for (const id in this.monsters) {
+            const m = this.monsters[id];
+            m.update(delta, players);
+            if (!m.alive) {
+                delete this.monsters[id];
+            }
+        }
+    }
+
+    getState() {
+        const state = {};
+        for (const id in this.monsters) {
+            const m = this.monsters[id];
+            state[id] = {
+                x: m.x,
+                y: m.y,
+                type: m.type,
+                state: m.state,
+                facing: m.facing,
+                hp: m.hp,
+                maxHp: m.maxHp
+            };
+        }
+        return state;
+    }
+
+    processPlayerAttack(player, type) {
+        const cfg = {
+            attack: { range: 85, angle: 90, damage: 1 },
+            secondary: { range: 110, angle: 110, damage: 2 }
+        }[type];
+        if (!cfg) return;
+        const playerAngle = directionStringToAngleRadians(player.facing || 'down');
+        for (const id in this.monsters) {
+            const m = this.monsters[id];
+            if (!m.alive) continue;
+            const dx = m.x - player.x;
+            const dy = m.y - player.y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            if (dist > cfg.range) continue;
+            let ang = Math.atan2(dy, dx);
+            let diff = Math.abs(ang - playerAngle);
+            if (diff > Math.PI) diff = 2 * Math.PI - diff;
+            if (diff <= (cfg.angle * Math.PI / 180) / 2) {
+                m.takeDamage(cfg.damage);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- keep only player physics on client
- sync monster health and remove dead monsters
- handle player attacks and monster attacks on the server
- include hp values in world state updates

## Testing
- `npm test` *(fails: Error: no test specified)*