### PR TITLE
Enable server-controlled monster spawning

### DIFF
--- a/src/js/entities/Player.js
+++ b/src/js/entities/Player.js
@@ -496,7 +496,7 @@ class CombatComponent extends Component {
         }
       }
     
-    performPrimaryAttack() {
+    performPrimaryAttack(skipNetwork = false) {
       console.log(`Primary attack (${this.owner.characterClass === 'guardian' ? 'sweeping axe' : 'forehand slash'}) started`);
       this.owner.isAttacking = true;
       this.owner.attackHitFrameReached = false;
@@ -505,14 +505,16 @@ class CombatComponent extends Component {
       // Play attack animation
       this.owner.animation.playAttackAnimation('primary');
       
-      // Execute attack using combat system
+      if (!skipNetwork && window.game && window.game.network) {
+        window.game.network.sendAction({ type: 'attack' });
+      }
       if (this.owner.combatSystem) {
         const cooldown = this.owner.combatSystem.executeAttack(this.owner, 'primary');
-        this.owner.primaryAttackCooldown = cooldown / 1000; // Store in the correct variable
+        this.owner.primaryAttackCooldown = cooldown / 1000;
       }
     }
     
-    performSecondaryAttack() {
+    performSecondaryAttack(skipNetwork = false) {
       console.log(`Secondary attack (${this.owner.characterClass === 'guardian' ? 'jump attack' : 'overhead smash'}) started`);
       this.owner.isAttacking = true;
       this.owner.attackHitFrameReached = false;
@@ -521,14 +523,16 @@ class CombatComponent extends Component {
       // Play attack animation
       this.owner.animation.playAttackAnimation('secondary');
       
-      // Execute attack using combat system
+      if (!skipNetwork && window.game && window.game.network) {
+        window.game.network.sendAction({ type: 'secondary' });
+      }
       if (this.owner.combatSystem) {
         const cooldown = this.owner.combatSystem.executeAttack(this.owner, 'secondary');
-        this.owner.secondaryAttackCooldown = cooldown / 1000; // Store in the correct variable
+        this.owner.secondaryAttackCooldown = cooldown / 1000;
       }
     }
 
-    performRoll() {
+    performRoll(skipNetwork = false) {
       console.log('Roll started');
       this.owner.isAttacking = true;
       this.owner.attackHitFrameReached = false;
@@ -536,6 +540,9 @@ class CombatComponent extends Component {
 
       this.owner.animation.playAttackAnimation('roll');
 
+      if (!skipNetwork && window.game && window.game.network) {
+        window.game.network.sendAction({ type: 'roll' });
+      }
       if (this.owner.combatSystem) {
         const cooldown = this.owner.combatSystem.executeAttack(this.owner, 'roll');
         this.owner.rollCooldown = cooldown / 1000;

--- a/src/js/network/NetworkClient.js
+++ b/src/js/network/NetworkClient.js
@@ -9,6 +9,8 @@ export class NetworkClient {
         this.socket.on('playerLeft', id => this.emit('playerLeft', id));
         this.socket.on('worldState', state => this.emit('worldState', state));
         this.socket.on('worldInit', data => this.emit('worldInit', data));
+        this.socket.on('playerAction', data => this.emit('playerAction', data));
+        this.socket.on('spawnProjectile', d => this.emit('spawnProjectile', d));
     }
 
     join(characterClass) {
@@ -17,6 +19,14 @@ export class NetworkClient {
 
     sendState(state) {
         this.socket.emit('state', state);
+    }
+
+    sendAction(action) {
+        this.socket.emit('playerAction', action);
+    }
+
+    sendProjectile(data) {
+        this.socket.emit('spawnProjectile', data);
     }
 
     on(event, fn) {

--- a/src/js/systems/CombatSystem.js
+++ b/src/js/systems/CombatSystem.js
@@ -167,6 +167,15 @@ export class CombatSystem {
       projectile.attachVisualEffect(effectSprite);
     }
     this.projectiles.push(projectile);
+    if (window.game && window.game.network) {
+      window.game.network.sendProjectile({
+        x, y, angle,
+        damage: options.damage || 1,
+        speed: options.speed || 600,
+        range: options.range || 400,
+        effectType: options.effectType || 'bow_shot_effect'
+      });
+    }
     return projectile;
   }
 

--- a/src/server/game/Monster.js
+++ b/src/server/game/Monster.js
@@ -1,0 +1,63 @@
+import { MONSTER_CONFIG } from '../../js/config/GameConfig.js';
+
+export class Monster {
+    constructor(options) {
+        this.id = options.id;
+        this.type = options.type || 'skeleton';
+        this.x = options.x;
+        this.y = options.y;
+
+        const stats = MONSTER_CONFIG.stats[this.type] || {};
+        this.moveSpeed = stats.moveSpeed || 2;
+        this.attackRange = stats.attackRange || 60;
+        this.aggroRange = stats.aggroRange || 200;
+
+        this.state = 'idle';
+        this.attackCooldown = 0;
+        this.facing = 'down';
+    }
+
+    update(delta, players) {
+        if (this.attackCooldown > 0) {
+            this.attackCooldown -= delta;
+        }
+        // Find nearest player
+        let closest = null;
+        let closestDist = Infinity;
+        for (const id in players) {
+            const p = players[id];
+            const dx = p.x - this.x;
+            const dy = p.y - this.y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            if (dist < closestDist) {
+                closest = p;
+                closestDist = dist;
+            }
+        }
+        if (closest) {
+            const dx = closest.x - this.x;
+            const dy = closest.y - this.y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            if (dist > this.attackRange) {
+                // Move toward player
+                const speed = this.moveSpeed * delta;
+                if (dist > 0) {
+                    this.x += (dx / dist) * speed;
+                    this.y += (dy / dist) * speed;
+                }
+                this.state = 'walking';
+            } else if (this.attackCooldown <= 0) {
+                this.state = 'attacking';
+                this.attackCooldown = 1.0; // 1 second
+            } else {
+                this.state = 'idle';
+            }
+            // Update facing
+            if (Math.abs(dx) > Math.abs(dy)) {
+                this.facing = dx > 0 ? 'right' : 'left';
+            } else {
+                this.facing = dy > 0 ? 'down' : 'up';
+            }
+        }
+    }
+}

--- a/src/server/game/MonsterSystem.js
+++ b/src/server/game/MonsterSystem.js
@@ -1,0 +1,87 @@
+import seedrandom from 'seedrandom';
+import { MONSTER_CONFIG } from '../../js/config/GameConfig.js';
+import { Monster } from './Monster.js';
+
+export class MonsterSystem {
+    constructor(seed) {
+        this.rng = seedrandom(seed);
+        this.monsters = {};
+        this.nextId = 1;
+        this.spawnTimer = 0;
+        this.spawnRate = MONSTER_CONFIG.spawn.timer;
+        this.maxMonsters = MONSTER_CONFIG.spawn.maxMonsters;
+        this.worldWidth = 100 * 64; // match client world size
+        this.worldHeight = 100 * 64;
+
+        this.spawnInitial();
+    }
+
+    spawnInitial() {
+        const centerX = this.worldWidth / 2;
+        const centerY = this.worldHeight / 2;
+        for (const spawn of MONSTER_CONFIG.testSpawns) {
+            for (let i = 0; i < spawn.count; i++) {
+                const x = centerX + spawn.offsetX + (this.rng() - 0.5) * 100;
+                const y = centerY + spawn.offsetY + (this.rng() - 0.5) * 100;
+                this.addMonster(spawn.type, x, y);
+            }
+        }
+    }
+
+    addMonster(type, x, y) {
+        const id = this.nextId++;
+        this.monsters[id] = new Monster({ id, type, x, y });
+    }
+
+    spawnRandom(players) {
+        const playerIds = Object.keys(players);
+        if (playerIds.length === 0) return;
+        // Pick a random player as spawn reference
+        const base = players[playerIds[Math.floor(this.rng() * playerIds.length)]];
+        const minDist = MONSTER_CONFIG.spawn.minDistanceFromPlayer;
+        const maxDist = MONSTER_CONFIG.spawn.maxDistanceFromPlayer;
+        for (let attempt = 0; attempt < 20; attempt++) {
+            const angle = this.rng() * Math.PI * 2;
+            const dist = minDist + this.rng() * (maxDist - minDist);
+            const x = base.x + Math.cos(angle) * dist;
+            const y = base.y + Math.sin(angle) * dist;
+            if (x < 0 || y < 0 || x > this.worldWidth || y > this.worldHeight) {
+                continue;
+            }
+
+            let roll = this.rng();
+            let chosenType = 'skeleton';
+            let total = 0;
+            for (const [type, prob] of Object.entries(MONSTER_CONFIG.spawn.distribution)) {
+                total += prob;
+                if (roll < total) {
+                    chosenType = type;
+                    break;
+                }
+            }
+            this.addMonster(chosenType, x, y);
+            break;
+        }
+    }
+
+    update(delta, players) {
+        this.spawnTimer += delta;
+        if (Object.keys(this.monsters).length < this.maxMonsters && this.spawnTimer >= this.spawnRate) {
+            this.spawnTimer = 0;
+            this.spawnRandom(players);
+        }
+
+        for (const id in this.monsters) {
+            this.monsters[id].update(delta, players);
+        }
+    }
+
+    getState() {
+        const state = {};
+        for (const id in this.monsters) {
+            const m = this.monsters[id];
+            state[id] = { x: m.x, y: m.y, type: m.type, state: m.state, facing: m.facing };
+        }
+        return state;
+    }
+}

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 import seedrandom from 'seedrandom';
+import { MonsterSystem } from './game/MonsterSystem.js';
 
 const app = express();
 const httpServer = createServer(app);
@@ -13,12 +14,13 @@ const io = new Server(httpServer, {
 const worldSeed = Math.floor(seedrandom()() * 1e8).toString();
 
 const players = {};
+const monsterSystem = new MonsterSystem(worldSeed);
 
 io.on('connection', socket => {
     console.log('Client connected', socket.id);
 
     // Send world seed and existing players to the newly connected client
-    socket.emit('worldInit', { seed: worldSeed, players });
+    socket.emit('worldInit', { seed: worldSeed, players, monsters: monsterSystem.getState() });
 
     socket.on('join', data => {
         players[socket.id] = {
@@ -39,6 +41,16 @@ io.on('connection', socket => {
         }
     });
 
+    socket.on('playerAction', action => {
+        action.id = socket.id;
+        socket.broadcast.emit('playerAction', action);
+    });
+
+    socket.on('spawnProjectile', data => {
+        data.ownerId = socket.id;
+        socket.broadcast.emit('spawnProjectile', data);
+    });
+
     socket.on('disconnect', () => {
         console.log('Client disconnected', socket.id);
         delete players[socket.id];
@@ -47,7 +59,8 @@ io.on('connection', socket => {
 });
 
 setInterval(() => {
-    io.emit('worldState', players);
+    monsterSystem.update(0.1, players);
+    io.emit('worldState', { players, monsters: monsterSystem.getState() });
 }, 100);
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- give Monster access to config stats on the server
- add periodic monster spawning logic on the server

## Testing
- `npm test` *(fails: Error: no test specified)*