### PR TITLE
Fix monster projectile collisions

### DIFF
--- a/src/js/entities/Projectile.js
+++ b/src/js/entities/Projectile.js
@@ -93,7 +93,13 @@ export class Projectile {
     }
     
     checkCollision(entity) {
-        if (!this.active || !entity.alive || entity === this.owner) return false;
+        if (!this.active || entity === this.owner) return false;
+
+        if (entity.hasOwnProperty('alive')) {
+            if (!entity.alive) return false;
+        } else if (entity.isDead) {
+            return false;
+        }
         
         // Simple circular collision
         const dx = entity.position.x - this.position.x;

--- a/src/js/systems/CombatSystem.js
+++ b/src/js/systems/CombatSystem.js
@@ -138,8 +138,31 @@ export class CombatSystem {
             this.projectiles.splice(i, 1);
             continue;
         }
+
         projectile.update(deltaTime);
-        const monsters = window.game.systems.monsters.monsters; // Consider passing monsters or using an event system
+
+        const monsters = window.game.systems.monsters.monsters;
+        const players = window.game.server?.gameState?.players
+                        ? Array.from(window.game.server.gameState.players.values())
+                        : [window.game.entities.player];
+
+        const ownerIsMonster = projectile.owner && projectile.owner.type;
+
+        if (ownerIsMonster) {
+            for (const player of players) {
+                if (!player || player.isDead) continue;
+                if (projectile.checkCollision(player)) {
+                    if (player.takeDamage) {
+                        player.takeDamage(projectile.damage, projectile.owner);
+                    }
+                    projectile.deactivate();
+                    break;
+                }
+            }
+        }
+
+        if (!projectile.active) continue;
+
         for (const monster of monsters) {
             if (!monster.alive) continue;
             if (projectile.checkCollision(monster)) {


### PR DESCRIPTION
## Summary
- allow `Projectile.checkCollision` to accept entities without an `alive` flag

## Testing
- `npm test` *(fails: no test specified)*