### PR TITLE
Add basic lobby and networking events

### DIFF
--- a/server/GameInstance.mjs
+++ b/server/GameInstance.mjs
@@ -9,10 +9,12 @@ export class GameInstance {
 
     addPlayer(player) {
         this.players.set(player.id, player);
+        this.broadcast('player_joined', { playerId: player.id });
     }
 
     removePlayer(playerId) {
         this.players.delete(playerId);
+        this.broadcast('player_left', { playerId });
     }
 
     handlePlayerInput(playerId, input) {
@@ -25,5 +27,12 @@ export class GameInstance {
     update(deltaTime) {
         // Placeholder for future server-side game loop
         this.lastUpdate = Date.now();
+    }
+
+    broadcast(event, data, excludeId = null) {
+        for (const p of this.players.values()) {
+            if (p.id === excludeId) continue;
+            p.socket.emit(event, data);
+        }
     }
 }

--- a/src/js/net/NetworkManager.js
+++ b/src/js/net/NetworkManager.js
@@ -5,6 +5,7 @@ export class NetworkManager {
     constructor(game) {
         this.game = game;
         this.socket = null;
+        this.gameId = null;
     }
 
     connect(serverUrl) {
@@ -16,6 +17,36 @@ export class NetworkManager {
         this.socket.on('game_state', (state) => {
             this.game.onServerMessage({ type: 'GAME_STATE', data: state });
         });
+
+        this.socket.on('game_created', ({ gameId }) => {
+            this.gameId = gameId;
+            console.log('Game created', gameId);
+        });
+
+        this.socket.on('join_result', ({ success, gameId }) => {
+            if (success) {
+                this.gameId = gameId;
+                console.log('Joined game', gameId);
+            } else {
+                console.warn('Failed to join game', gameId);
+            }
+        });
+
+        this.socket.on('player_joined', ({ playerId }) => {
+            console.log('Player joined', playerId);
+        });
+
+        this.socket.on('player_left', ({ playerId }) => {
+            console.log('Player left', playerId);
+        });
+
+        this.socket.on('player_class_selected', ({ playerId, className }) => {
+            console.log('Player', playerId, 'selected class', className);
+        });
+
+        this.socket.on('player_ready', ({ playerId }) => {
+            console.log('Player ready', playerId);
+        });
     }
 
     isConnected() {
@@ -25,6 +56,30 @@ export class NetworkManager {
     sendInput(input) {
         if (this.isConnected()) {
             this.socket.emit('input', { type: ClientMessages.INPUT, data: input });
+        }
+    }
+
+    createGame() {
+        if (this.isConnected()) {
+            this.socket.emit('create_game');
+        }
+    }
+
+    joinGame(gameId) {
+        if (this.isConnected()) {
+            this.socket.emit('join_game', { gameId });
+        }
+    }
+
+    selectClass(className) {
+        if (this.isConnected()) {
+            this.socket.emit('class_select', { className });
+        }
+    }
+
+    setReady() {
+        if (this.isConnected()) {
+            this.socket.emit('player_ready');
         }
     }
 }

--- a/src/js/ui/LobbyUI.js
+++ b/src/js/ui/LobbyUI.js
@@ -1,0 +1,46 @@
+import * as PIXI from 'pixi.js';
+
+export class LobbyUI {
+    constructor(onCreate, onJoin) {
+        this.container = new PIXI.Container();
+        this.onCreate = onCreate;
+        this.onJoin = onJoin;
+
+        const createBtn = this._makeButton('CREATE GAME');
+        createBtn.position.set(window.innerWidth / 2 - 100, window.innerHeight / 2 - 80);
+        createBtn.on('pointerdown', () => {
+            if (this.onCreate) this.onCreate();
+        });
+        this.container.addChild(createBtn);
+
+        const joinBtn = this._makeButton('JOIN GAME');
+        joinBtn.position.set(window.innerWidth / 2 - 100, window.innerHeight / 2);
+        joinBtn.on('pointerdown', () => {
+            const gameId = window.prompt('Enter Game ID');
+            if (gameId && this.onJoin) {
+                this.onJoin(gameId);
+            }
+        });
+        this.container.addChild(joinBtn);
+    }
+
+    _makeButton(label) {
+        const btn = new PIXI.Graphics();
+        btn.beginFill(0x34495e);
+        btn.drawRoundedRect(0, 0, 200, 50, 10);
+        btn.endFill();
+        btn.interactive = true;
+        btn.cursor = 'pointer';
+
+        const text = new PIXI.Text(label, {
+            fontFamily: 'Arial',
+            fontSize: 20,
+            fill: 0xffffff,
+            align: 'center'
+        });
+        text.anchor.set(0.5);
+        text.position.set(100, 25);
+        btn.addChild(text);
+        return btn;
+    }
+}


### PR DESCRIPTION
## Summary
- implement broadcast helpers in `GameInstance`
- expand `GameServer` with create/join game and ready/class events
- enhance `NetworkManager` with lobby-related messages
- add `LobbyUI` for simple create/join interface
- hook lobby flow into `Game` when networking is enabled

## Testing
- `npm test` *(fails: no test specified)*