### PR TITLE
Implement reliable/unreliable event mapping

### DIFF
--- a/server/GameServer.mjs
+++ b/server/GameServer.mjs
@@ -1,5 +1,6 @@
 import { Server } from 'socket.io';
 import { GameInstance } from './GameInstance.mjs';
+import { emitWithReliability } from './NetUtils.mjs';
 
 export class GameServer {
     constructor(httpServer) {
@@ -46,13 +47,13 @@ export class GameServer {
         socket.on('create_game', () => {
             const player = this.players.get(socket.id);
             const gameId = this.createGame(player);
-            socket.emit('game_created', { gameId });
+            emitWithReliability(socket, 'game_created', { gameId });
         });
 
         socket.on('join_game', ({ gameId }) => {
             const player = this.players.get(socket.id);
             const success = this.joinGame(gameId, player);
-            socket.emit('join_result', { success, gameId });
+            emitWithReliability(socket, 'join_result', { success, gameId });
         });
 
         socket.on('class_select', ({ className }) => {

--- a/server/NetUtils.mjs
+++ b/server/NetUtils.mjs
@@ -1,0 +1,18 @@
+import { ReliableServerEvents } from '../src/js/net/EventReliability.js';
+
+export function sendReliable(socket, event, data) {
+    socket.emit(event, data);
+}
+
+export function sendUnreliable(socket, event, data) {
+    socket.emit(event, data);
+}
+
+export function emitWithReliability(socket, event, data) {
+    if (ReliableServerEvents.has(event)) {
+        sendReliable(socket, event, data);
+    } else {
+        sendUnreliable(socket, event, data);
+    }
+}
+

--- a/src/js/net/EventReliability.js
+++ b/src/js/net/EventReliability.js
@@ -1,0 +1,20 @@
+export const ReliableClientEvents = new Set([
+    'create_game',
+    'join_game',
+    'class_select',
+    'player_ready'
+]);
+
+export const ReliableServerEvents = new Set([
+    'game_created',
+    'join_result',
+    'player_joined',
+    'player_left',
+    'player_class_selected',
+    'player_ready',
+    'ENTITY_SPAWN',
+    'ENTITY_DESPAWN',
+    'DAMAGE_EVENT',
+    'CHAT_MESSAGE'
+]);
+

--- a/src/js/net/NetworkManager.js
+++ b/src/js/net/NetworkManager.js
@@ -1,5 +1,6 @@
 import { io } from 'socket.io-client';
 import { ClientMessages } from './MessageTypes.js';
+import { ReliableClientEvents } from './EventReliability.js';
 
 export class NetworkManager {
     constructor(game) {
@@ -65,23 +66,31 @@ export class NetworkManager {
         }
     }
 
+    send(event, data) {
+        if (ReliableClientEvents.has(event)) {
+            this.sendReliable(event, data);
+        } else {
+            this.sendUnreliable(event, data);
+        }
+    }
+
     sendInput(input) {
-        this.sendUnreliable('input', { type: ClientMessages.INPUT, data: input });
+        this.send('input', { type: ClientMessages.INPUT, data: input });
     }
 
     createGame() {
-        this.sendReliable('create_game');
+        this.send('create_game');
     }
 
     joinGame(gameId) {
-        this.sendReliable('join_game', { gameId });
+        this.send('join_game', { gameId });
     }
 
     selectClass(className) {
-        this.sendReliable('class_select', { className });
+        this.send('class_select', { className });
     }
 
     setReady() {
-        this.sendReliable('player_ready');
+        this.send('player_ready');
     }
 }


### PR DESCRIPTION
## Summary
- define which client and server events should be sent reliably
- route all outgoing events through a helper that checks reliability
- use the helper in the server and client

## Testing
- `npm test` *(fails: Error: no test specified)*