### PR TITLE
Add player info handshake

### DIFF
--- a/server/GameInstance.mjs
+++ b/server/GameInstance.mjs
@@ -93,6 +93,10 @@ export class GameInstance {
         ];
         const relevant = getRelevantEntities(entity, allEntities, this.viewDistance);
         const snapshot = buildFullState(relevant, this.state.timestamp);
+        player.socket.emit('player_info', {
+            playerId: player.id,
+            position: { ...entity.position }
+        });
         player.socket.emit('game_state', snapshot);
         this.lastStates.set(player.id, { entities: relevant, timestamp: this.state.timestamp });
         this.broadcast('player_joined', { playerId: player.id }, player.id);

--- a/src/js/core/Game.js
+++ b/src/js/core/Game.js
@@ -225,6 +225,18 @@ export class Game {
   }
 
   onServerMessage(message) {
+    if (message.type === ServerMessages.PLAYER_INFO) {
+      const info = message.data || {};
+      if (this.entities.player) {
+        this.entities.player.id = info.playerId || this.entities.player.id;
+        if (info.position) {
+          this.entities.player.position.x = info.position.x;
+          this.entities.player.position.y = info.position.y;
+          this.entities.player.sprite.position.set(info.position.x, info.position.y);
+        }
+      }
+      return;
+    }
     if (message.type === ServerMessages.GAME_STATE) {
       const data = message.data;
       const timestamp = data.timestamp || data.tick || Date.now();

--- a/src/js/net/LocalServer.js
+++ b/src/js/net/LocalServer.js
@@ -60,6 +60,10 @@ export class LocalServer {
         this.lastStates.set(clientId, snapshot);
         const client = this.clients.get(clientId);
         if (client && client.onServerMessage) {
+            client.onServerMessage({
+                type: ServerMessages.PLAYER_INFO,
+                data: { playerId: player.id, position: { x: player.position.x, y: player.position.y } }
+            });
             client.onServerMessage({ type: ServerMessages.GAME_STATE, data: buildFullState(entities, snapshot.timestamp) });
         }
     }

--- a/src/js/net/MessageTypes.js
+++ b/src/js/net/MessageTypes.js
@@ -7,6 +7,7 @@ export const ClientMessages = {
 
 export const ServerMessages = {
     GAME_STATE: 'GAME_STATE',
+    PLAYER_INFO: 'PLAYER_INFO',
     PLAYER_JOINED: 'PLAYER_JOINED',
     PLAYER_LEFT: 'PLAYER_LEFT',
     ENTITY_SPAWN: 'ENTITY_SPAWN',

--- a/src/js/net/NetworkManager.js
+++ b/src/js/net/NetworkManager.js
@@ -18,6 +18,10 @@ export class NetworkManager {
             this.game.onServerMessage({ type: 'GAME_STATE', data: state });
         });
 
+        this.socket.on('player_info', (info) => {
+            this.game.onServerMessage({ type: 'PLAYER_INFO', data: info });
+        });
+
         this.socket.on('game_created', ({ gameId }) => {
             this.gameId = gameId;
             console.log('Game created', gameId);


### PR DESCRIPTION
## Summary
- assign `PLAYER_INFO` message type
- send `player_info` event from the server when a player joins
- forward `player_info` to the game client
- update the Game class to handle `PLAYER_INFO` messages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683a2edf134c8323a73e950414b76c28